### PR TITLE
feat: organize shop listing by Title ID (Game ID)

### DIFF
--- a/src/create-index-content.js
+++ b/src/create-index-content.js
@@ -14,6 +14,25 @@ const validExtensions = ["nsp", "nsz", "xci", "zip"].map(
   (value) => `**.${value.replace(".", "")}`
 );
 
+// Extracts the 16-character hex Title ID from a filename.
+// e.g. "Game Name [010010401BC1A000][v0] (0.39 GB).nsz" → "010010401BC1A000"
+// Returns null if no Title ID is found.
+function extractTitleId(filePath) {
+  const filename = path.basename(filePath);
+  const match = filename.match(/\[([0-9A-Fa-f]{16})\]/);
+  return match ? match[1].toUpperCase() : null;
+}
+
+// Sorts files by Title ID so base game, updates and DLC appear grouped together.
+// Files without a Title ID are placed at the end.
+function sortByTitleId(files) {
+  return [...files].sort((a, b) => {
+    const idA = extractTitleId(a.url) ?? "\xFF";
+    const idB = extractTitleId(b.url) ?? "\xFF";
+    return idA.localeCompare(idB);
+  });
+}
+
 export default async () => {
 
   const jsonTemplate = getJsonTemplateFile();
@@ -40,9 +59,11 @@ export default async () => {
       jsonTemplate.success = welcomeMessage;
     }
   }
-  files = (await Promise.all(files.map(addFileInfoToPath)))
-    .map(encodeURL)
-    .map(addRelativeStartPath);
+  files = sortByTitleId(
+    (await Promise.all(files.map(addFileInfoToPath)))
+      .map(encodeURL)
+      .map(addRelativeStartPath)
+  );
 
   directories = directories
     .map((file) => {

--- a/test/switch/home-brews.spec.ts
+++ b/test/switch/home-brews.spec.ts
@@ -22,8 +22,24 @@ test.describe('Roms and homebrews listing', () => {
         ],
         "success": "The Server Works!!"
       })
+  });
 
-    // Expect a title "to contain" a substring.
+  test('Files are sorted by Title ID (base game before updates/DLC)', async ({ nxPage }) => {
+    const response = await nxPage.request.get(`/shop.json`);
+    expect(response.ok()).toBeTruthy();
+    const { files } = await response.json();
+
+    const titleIdPattern = /\[([0-9A-Fa-f]{16})\]/;
+    const titleIds = files
+      .map((f: { url: string }) => {
+        const decoded = decodeURIComponent(f.url);
+        const match = decoded.match(titleIdPattern);
+        return match ? match[1].toUpperCase() : null;
+      })
+      .filter(Boolean);
+
+    const sorted = [...titleIds].sort((a: string, b: string) => a.localeCompare(b));
+    expect(titleIds).toEqual(sorted);
   });
 
 })


### PR DESCRIPTION
## Summary
- Extract the 16-character hex Title ID from each filename using the `[XXXXXXXXXXXXXXXX]` bracket pattern
- Sort the `files` array by Title ID so base game, updates, and DLC for the same title appear grouped together in the Tinfoil listing
- Files without a recognisable Title ID fall to the end

## Test plan
- [x] Existing listing test still passes (sort order preserved for test fixtures)
- [x] New test asserts files in `/shop.json` are returned in ascending Title ID order

🤖 Generated with [Claude Code](https://claude.com/claude-code)